### PR TITLE
Bump node-exporter version from 1.2.0 to 1.3.1

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 options:
   node-exporter-version:
     type: string
-    default: "1.2.0"
+    default: "1.3.1"
     description: >
       The node-exporter version to install.
   listen-address:


### PR DESCRIPTION
Updates the default version of node-exporter to 1.3.1, which contains a fix for the excess error messages when the machine does not contain an NVM Express driver.

https://github.com/prometheus/node_exporter/blob/master/CHANGELOG.md

Final checklist
- [x] I am the author of these changes, or I have the rights to submit them.
- [ ] I added the relevant changed to the README and/or documentation.
- [x] I self reviewed my own code.
